### PR TITLE
Remove large vertical gap on first P in a Blockquote

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -40,6 +40,10 @@ blockquote, p blockquote {
   font-style: italic;
 }
 
+blockquote p:first-child {
+  margin-top: 0;
+}
+
 blockquote {
   color: #808080;
   font-style: italic;


### PR DESCRIPTION
Fixes #1 

This change removes the large vertical gap present in the first `<p>` of a `<blockquote>`

For instance, using this markup
```html
<blockquote>
  <p>like this</p>
  <p>like this</p>
  <p>like this</p>
</blockquote>
```

Before this change

<img width="383" alt="before" src="https://user-images.githubusercontent.com/864570/32256875-3afdfaa6-be88-11e7-8484-d628d4b6d1ea.png">

After the change

<img width="384" alt="after" src="https://user-images.githubusercontent.com/864570/32256876-3b0e07a2-be88-11e7-9710-2f90aa607a6b.png">
