### PR TITLE
Bugfix: avatar border shows with no avatar

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,6 +16,10 @@
   <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/main.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" />
 
+  {{ range .Site.Params.custom_stylesheets }}
+  <link rel="stylesheet" href="{{ . | absURL }}" />
+  {{ end }}
+
   <!-- Facebook OpenGraph tags -->
   <meta property="og:title" content="{{ .Title }}" />
   <meta property="og:type" content="website" />

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -31,15 +31,15 @@
       </ul>
     </div>
 
+  {{ if isset .Site.Params "logo" }}
 	<div class="avatar-container">
 	  <div class="avatar-img-border">
-      {{ if isset .Site.Params "logo" }}
-          <a title="{{ .Site.Title }}" href="{{ .Site.BaseURL }}">
-              <img class="avatar-img" src="{{ .Site.BaseURL }}/{{ .Site.Params.logo }}" alt="{{ .Site.Title }}" />
-          </a>
-      {{ end }}
+        <a title="{{ .Site.Title }}" href="{{ .Site.BaseURL }}">
+            <img class="avatar-img" src="{{ .Site.BaseURL }}/{{ .Site.Params.logo }}" alt="{{ .Site.Title }}" />
+        </a>
 	  </div>
 	</div>
+  {{ end }}
 
   </div>
 </nav>


### PR DESCRIPTION
If the site doesn't specify an avatar logo, the border will still show,
but the avatar itself will be empty, causing a weird looking ellipse
thing to be rendered on the page.

This encapsulates the whole of the avatar html in the check for the
site logo, causing none of it to be rendered when there isn't one.